### PR TITLE
Fix URL validation

### DIFF
--- a/code/Python/support/classic_validate.py
+++ b/code/Python/support/classic_validate.py
@@ -14,12 +14,21 @@ def validateStrParameter(param, name, defaultValue):
 
 def validateURLParameter(param, name, defaultValue):
     try:
-        socket.gethostbyname(param)
-        return param
-    except Exception as e:
+        assert len(param) < 255
+        # Permit name to end with a single dot.
+        hostname = param[:-1] if param.endswith('.') else param
+        # check each hostname segment
+        allowed = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+        assert all(allowed.match(s) for s in hostname.split("."))
+    except:
         log.error("Invalid parameter, {} passed for {}".format(param, name))
-        log.exception(e, exc_info=False)
         return defaultValue
+    try:
+        socket.gethostbyname(param)
+    except Exception as e:
+        log.warning("Name resolution failed for {} passed for {}".format(param, name))
+        log.exception(e, exc_info=False)
+    return param
 
 def validateIntParameter(param, name, defaultValue):
     try: 


### PR DESCRIPTION
The `validateURLParameter` function is too strict, in that it rejects a valid (but currently unavailable) hostname, replacing it with the default.

In the case where my cabin is coming back online, the Midnite Classic boots more slowly than my Raspberry Pi.  This causes the name lookup to fail -- then retries are performed with the default value, instead of the configured value.

This change:

* Fails if not a valid hostname/IP address, returning the default instead
* Warns if the address is not reachable, but permits it to be used