### PR TITLE
Set default arguments to environment variables if they are defined

### DIFF
--- a/code/Python/classic_mqtt.py
+++ b/code/Python/classic_mqtt.py
@@ -40,8 +40,9 @@ MAIN_LOOP_SLEEP_SECS        = 5         #Seconds to sleep in the main loop
 # Default startup values. Can be over-ridden by command line options.
 # --------------------------------------------------------------------------- # 
 argumentValues = { \
-    'classicHost':"ClassicHost", 'classicPort':"502", 'classicName':"classic", \
-    'mqttHost':"127.0.0.1", 'mqttPort':"1883", 'mqttRoot':"ClassicMQTT", 'mqttUser':"username", 'mqttPassword':"password", \
+    'classicHost':os.getenv('CLASSIC', "ClassicHost"), 'classicPort':os.getenv('CLASSIC_PORT', "502"), 'classicName':os.getenv('CLASSIC_NAME', "classic"), \
+    'mqttHost':os.getenv('MQTT_HOST', "127.0.0.1"), 'mqttPort':os.getenv('MQTT_PORT', "1883"), \
+    'mqttRoot':os.getenv('MQTT_ROOT', "ClassicMQTT"), 'mqttUser':os.getenv('MQTT_USER', "ClassicPublisher"), 'mqttPassword':os.getenv('MQTT_PASS', "ClassicPub123"), \
     'awakePublishRate':DEFAULT_WAKE_RATE, \
     'snoozePublishRate':DEFAULT_SNOOZE_RATE, \
     'awakePublishLimit':DEFAULT_WAKE_PUBLISHES}

--- a/code/Python/compose-override.yml
+++ b/code/Python/compose-override.yml
@@ -17,8 +17,8 @@ services:
       - iotstack_nw
 
 # uncomment the following block if you have a second classic, change the CLASSIC ip address and CLASSIC_NAME
-#  classic_mqtt:
-#    container_name: classic_mqtt
+#  classic_mqtt2:
+#    container_name: classic_mqtt2
 #    image: classicdiy/classicmqtt
 #    restart: unless-stopped
 #    environment:

--- a/code/Python/compose-override.yml
+++ b/code/Python/compose-override.yml
@@ -5,8 +5,49 @@ services:
     restart: unless-stopped
     environment:
       - LOGLEVEL=DEBUG
-    depends_on:
-      - mosquitto
+      - CLASSIC=192.168.86.37
+      - CLASSIC_PORT=502
+      - CLASSIC_NAME=MyWorkshop
+      - MQTT_HOST=mosquitto
+      - MQTT_PORT=1883
+      - MQTT_ROOT=ClassicMQTT
+      - MQTT_USER=ClassicPublisher
+      - MQTT_PASS=ClassicPub123
     networks:
       - iotstack_nw
-    command: "--classic_name ${CLASSIC_NAME} --classic ${CLASSIC} --classic_port ${CLASSIC_PORT} --mqtt mosquitto --mqtt_root ${MQTT_ROOT} --mqtt_user ${MQTT_USER} --mqtt_pass ${MQTT_PASS}"
+
+# uncomment the following block if you have a second classic, change the CLASSIC ip address and CLASSIC_NAME
+#  classic_mqtt:
+#    container_name: classic_mqtt
+#    image: classicdiy/classicmqtt
+#    restart: unless-stopped
+#    environment:
+#      - LOGLEVEL=DEBUG
+#      - CLASSIC=192.168.86.137
+#      - CLASSIC_PORT=502
+#      - CLASSIC_NAME=MyShed
+#      - MQTT_HOST=mosquitto
+#      - MQTT_PORT=1883
+#      - MQTT_ROOT=ClassicMQTT
+#      - MQTT_USER=ClassicPublisher
+#      - MQTT_PASS=ClassicPub123
+#    networks:
+#      - iotstack_nw
+
+# Here is an example using an external MQTT broker
+#  classic_mqtt:
+#    container_name: classic_mqtt
+#    image: classicdiy/classicmqtt
+#    restart: unless-stopped
+#    environment:
+#      - LOGLEVEL=DEBUG
+#      - CLASSIC=192.168.86.37
+#      - CLASSIC_PORT=502
+#      - CLASSIC_NAME=MyWorkshop
+#      - MQTT_HOST=192.168.86.82
+#      - MQTT_PORT=1883
+#      - MQTT_ROOT=ClassicMQTT
+#      - MQTT_USER=HASSUser
+#      - MQTT_PASS=HASSpw
+#    networks:
+#      - iotstack_nw


### PR DESCRIPTION
Update to allow docker compose to define environment values, original defaults are used if environment variables are not defined