### PR TITLE
Major looping and modbus read re-write.

### DIFF
--- a/code/ESP32/ClassicMQTT/include/Log.h
+++ b/code/ESP32/ClassicMQTT/include/Log.h
@@ -11,6 +11,14 @@ void inline printHexString(char* ptr, int len)
 #endif
 }
 
+void inline printCharString(char* ptr, int len)
+{
+#if APP_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
+	esp_log_level_set(TAG, ESP_LOG_DEBUG);
+	esp_log_buffer_char_internal(TAG, ptr, len, ESP_LOG_DEBUG);
+#endif
+}
+
 #if APP_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_VERBOSE
 #define logv(format, ...) log_printf(ARDUHAL_LOG_FORMAT(V, format), ##__VA_ARGS__)
 #else

--- a/code/ESP32/ClassicMQTT/src/main.cpp
+++ b/code/ESP32/ClassicMQTT/src/main.cpp
@@ -328,8 +328,11 @@ int readModbus()
 
 void Wake()
 {
-	_currentPublishRate = _wakePublishRate;
-	_nextPublishTime = 0;
+	if (_currentPublishRate != _wakePublishRate)
+	{
+		_currentPublishRate = _wakePublishRate;
+		_nextPublishTime = 0;
+	}
 	_boilerPlateInfoPublished = false;
 	_publishAttemptCount = 0;
 }


### PR DESCRIPTION
As discussed, I have reworked the looping to call for a publish periodically. The wake publish rate is limited to not fater than every 5 seconds. When publish time comes around, the buffer flags are cleared and an attempt is made to fill them again. Once filled, the data is published to mqtt. Only one modbus async read is allowed at a time. So when multiple reads need to be done, that are done sequentially. If the modbus read does not return or errors out the publish does not happen. There is a timer that will clear the modbus read flag if the read never returns or errors out as a safety.