### PR TITLE
Add support for pymodbus 3.x.x

### DIFF
--- a/code/Python/classic_mqtt.py
+++ b/code/Python/classic_mqtt.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
 
-from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+try:
+    from pymodbus.client import ModbusTcpClient as ModbusClient  # pymodbus 3
+except ImportError:
+    from pymodbus.client.sync import ModbusTcpClient as ModbusClient  # pymodbus 2
 from paho.mqtt import client as mqttclient
 from collections import OrderedDict
 import json


### PR DESCRIPTION
This is an implementation of the changes mentioned in #35, plus the removal of the `from pymodbus.compat import iteritems` line, as `pymodbus.compat` doesn't exist in version 3, and the line was unused anyways.

Summary of changes for `classic_mqtt.py`:
* Catch import error if pymodbus 3 doesn't load, and try pymodbus 2

Summary of changes for `support/classic_modbusdecoder.py`:
* Catch import error if pymodbus 3 doesn't load, and try pymodbus 2
* Flag what `pymodbus` version we're using
* use `slave=` for version 3 and `unit=` for version 2.

I could also just drop support for pymodbus 2, but it seems pretty easy and straightforward to keep it.