### PR TITLE
Fixed connection closing of client and BinaryPayloadDecoder soon to be a deprecated class in pymodbus

### DIFF
--- a/code/Python/support/Payload.py
+++ b/code/Python/support/Payload.py
@@ -1,0 +1,673 @@
+"""Modbus Payload Builders.
+
+A collection of utilities for building and decoding
+modbus messages payloads.
+
+2024-12-31 - Daniel Côté
+Isolated and modified from pymodbus 3.8.2 with the announcement
+that it is deprecated and will be removed in next version.
+
+Useful for decoding/encoding bytes in Modicon word registers.
+
+Author of pymodbus believe only word bound data should be supported
+in pymodbus and it is to the application to deal with the registers'
+content.
+
+https://github.com/pymodbus-dev/pymodbus/discussions/2525
+https://github.com/pymodbus-dev/pymodbus/discussions/2520
+
+"""
+from __future__ import annotations
+
+
+__all__ = [
+    "BinaryPayloadBuilder",
+    "BinaryPayloadDecoder",
+]
+
+from array import array
+import enum
+
+# pylint: disable=missing-type-doc
+from struct import pack, unpack
+
+import logging
+
+class Log:
+    """Class to hide logging complexity.
+
+    :meta private:
+    """
+
+    _logger = logging.getLogger(__name__)
+
+    @classmethod
+    def apply_logging_config(cls, level, log_file_name):
+        """Apply basic logging configuration."""
+        if level == logging.NOTSET:
+            level = cls._logger.getEffectiveLevel()
+        if isinstance(level, str):
+            level = level.upper()
+        log_stream_handler = logging.StreamHandler()
+        log_formatter = logging.Formatter(
+            "%(asctime)s %(levelname)-5s %(module)s:%(lineno)s %(message)s"
+        )
+        log_stream_handler.setFormatter(log_formatter)
+        cls._logger.addHandler(log_stream_handler)
+        if log_file_name:
+            log_file_handler = logging.FileHandler(log_file_name)
+            log_file_handler.setFormatter(log_formatter)
+            cls._logger.addHandler(log_file_handler)
+        cls.setLevel(level)
+
+    @classmethod
+    def setLevel(cls, level):
+        """Apply basic logging level."""
+        cls._logger.setLevel(level)
+
+    @classmethod
+    def build_msg(cls, txt, *args):
+        """Build message."""
+        string_args = []
+        count_args = len(args) - 1
+        skip = False
+        for i in range(count_args + 1):
+            if skip:
+                skip = False
+                continue
+            if (
+                i < count_args
+                and isinstance(args[i + 1], str)
+                and args[i + 1][0] == ":"
+            ):
+                if args[i + 1] == ":hex":
+                    string_args.append(hexlify_packets(args[i]))
+                elif args[i + 1] == ":str":
+                    string_args.append(str(args[i]))
+                elif args[i + 1] == ":b2a":
+                    string_args.append(b2a_hex(args[i]))
+                skip = True
+            else:
+                string_args.append(args[i])
+        return txt.format(*string_args)
+
+    @classmethod
+    def info(cls, txt, *args):
+        """Log info messages."""
+        if cls._logger.isEnabledFor(logging.INFO):
+            cls._logger.info(cls.build_msg(txt, *args), stacklevel=2)
+
+    @classmethod
+    def debug(cls, txt, *args):
+        """Log debug messages."""
+        if cls._logger.isEnabledFor(logging.DEBUG):
+            cls._logger.debug(cls.build_msg(txt, *args), stacklevel=2)
+
+    @classmethod
+    def warning(cls, txt, *args):
+        """Log warning messages."""
+        if cls._logger.isEnabledFor(logging.WARNING):
+            cls._logger.warning(cls.build_msg(txt, *args), stacklevel=2)
+
+    @classmethod
+    def error(cls, txt, *args):
+        """Log error messages."""
+        if cls._logger.isEnabledFor(logging.ERROR):
+            cls._logger.error(cls.build_msg(txt, *args), stacklevel=2)
+
+    @classmethod
+    def critical(cls, txt, *args):
+        """Log critical messages."""
+        if cls._logger.isEnabledFor(logging.CRITICAL):
+            cls._logger.critical(cls.build_msg(txt, *args), stacklevel=2)
+
+# --------------------------------------------------------------------------- #
+# Bit packing functions
+# --------------------------------------------------------------------------- #
+def pack_bitstring(bits: list[bool]) -> bytes:
+    """Create a bytestring out of a list of bits.
+
+    :param bits: A list of bits
+
+    example::
+
+        bits   = [False, True, False, True]
+        result = pack_bitstring(bits)
+    """
+    ret = b""
+    i = packed = 0
+    for bit in bits:
+        if bit:
+            packed += 128
+        i += 1
+        if i == 8:
+            ret += struct.pack(">B", packed)
+            i = packed = 0
+        else:
+            packed >>= 1
+    if 0 < i < 8:
+        packed >>= 7 - i
+        ret += struct.pack(">B", packed)
+    return ret
+
+
+def unpack_bitstring(data: bytes) -> list[bool]:
+    """Create bit list out of a bytestring.
+
+    :param data: The modbus data packet to decode
+
+    example::
+
+        bytes  = "bytes to decode"
+        result = unpack_bitstring(bytes)
+    """
+    byte_count = len(data)
+    bits = []
+    for byte in range(byte_count):
+        value = int(data[byte])
+        for _ in range(8):
+            bits.append((value & 1) == 1)
+            value >>= 1
+    return bits
+
+class ModbusException(Exception):
+    """Base modbus exception."""
+
+    def __init__(self, string):
+        """Initialize the exception.
+
+        :param string: The message to append to the error
+        """
+        self.string = string
+        super().__init__(string)
+
+    def __str__(self):
+        """Return string representation."""
+        return f"Modbus Error: {self.string}"
+
+    def isError(self):
+        """Error"""
+        return True
+
+class ParameterException(ModbusException):
+    """Error resulting from invalid parameter."""
+
+    def __init__(self, string=""):
+        """Initialize the exception.
+
+        :param string: The message to append to the error
+        """
+        message = f"[Invalid Parameter] {string}"
+        ModbusException.__init__(self, message)
+
+class Endian(str, enum.Enum):
+    """An enumeration representing the various byte endianness.
+
+    .. attribute:: AUTO
+
+       This indicates that the byte order is chosen by the
+       current native environment.
+
+    .. attribute:: BIG
+
+       This indicates that the bytes are in big endian format
+
+    .. attribute:: LITTLE
+
+       This indicates that the bytes are in little endian format
+
+    .. note:: I am simply borrowing the format strings from the
+       python struct module for my convenience.
+    """
+
+    AUTO = "@"
+    BIG = ">"
+    LITTLE = "<"
+
+class BinaryPayloadBuilder:
+    """A utility that helps build payload messages to be written with the various modbus messages.
+
+    It really is just a simple wrapper around the struct module,
+    however it saves time looking up the format strings.
+    What follows is a simple example::
+
+        builder = BinaryPayloadBuilder(byteorder=Endian.Little)
+        builder.add_8bit_uint(1)
+        builder.add_16bit_uint(2)
+        payload = builder.build()
+    """
+
+    def __init__(
+        self, payload=None, byteorder=Endian.LITTLE, wordorder=Endian.BIG, repack=False
+    ):
+        """Initialize a new instance of the payload builder.
+
+        :param payload: Raw binary payload data to initialize with
+        :param byteorder: The endianness of the bytes in the words
+        :param wordorder: The endianness of the word (when wordcount is >= 2)
+        :param repack: Repack the provided payload based on BO
+        """
+
+        self._payload = payload or []
+        self._byteorder = byteorder
+        self._wordorder = wordorder
+        self._repack = repack
+
+    def _pack_words(self, fstring: str, value) -> bytes:
+        """Pack words based on the word order and byte order.
+
+        # ---------------------------------------------- #
+        # pack in to network ordered value               #
+        # unpack in to network ordered  unsigned integer #
+        # Change Word order if little endian word order  #
+        # Pack values back based on correct byte order   #
+        # ---------------------------------------------- #
+
+        :param fstring:
+        :param value: Value to be packed
+        :return:
+        """
+        value = pack(f"!{fstring}", value)
+        if Endian.LITTLE in {self._byteorder, self._wordorder}:
+            value = array("H", value)
+            if self._byteorder == Endian.LITTLE:
+                value.byteswap()
+            if self._wordorder == Endian.LITTLE:
+                value.reverse()
+            value = value.tobytes()
+        return value
+
+    def encode(self) -> bytes:
+        """Get the payload buffer encoded in bytes."""
+
+        return b"".join(self._payload)
+
+    def __str__(self) -> str:
+        """Return the payload buffer as a string.
+
+        :returns: The payload buffer as a string
+        """
+        return self.encode().decode("utf-8")
+
+    def reset(self) -> None:
+        """Reset the payload buffer."""
+
+        self._payload = []
+
+    def to_registers(self):
+        """Convert the payload buffer to register layout that can be used as a context block.
+
+        :returns: The register layout to use as a block
+        """
+
+        # fstring = self._byteorder+"H"
+        fstring = "!H"
+        payload = self.build()
+        if self._repack:
+            payload = [unpack(self._byteorder + "H", value)[0] for value in payload]
+        else:
+            payload = [unpack(fstring, value)[0] for value in payload]
+        Log.debug("Payload: {}", payload)
+        return payload
+
+    def to_coils(self) -> list[bool]:
+        """Convert the payload buffer into a coil layout that can be used as a context block.
+
+        :returns: The coil layout to use as a block
+        """
+
+        payload = self.to_registers()
+        coils = [bool(int(bit)) for reg in payload for bit in format(reg, "016b")]
+        return coils
+
+    def build(self) -> list[bytes]:
+        """Return the payload buffer as a list.
+
+        This list is two bytes per element and can
+        thus be treated as a list of registers.
+
+        :returns: The payload buffer as a list
+        """
+
+        buffer = self.encode()
+        length = len(buffer)
+        buffer += b"\x00" * (length % 2)
+        return [buffer[i : i + 2] for i in range(0, length, 2)]
+
+    def add_bits(self, values: list[bool]) -> None:
+        """Add a collection of bits to be encoded.
+
+        If these are less than a multiple of eight,
+        they will be left padded with 0 bits to make
+        it so.
+
+        :param values: The value to add to the buffer
+        """
+
+        value = pack_bitstring(values)
+        self._payload.append(value)
+
+    def add_8bit_uint(self, value: int) -> None:
+        """Add a 8 bit unsigned int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = self._byteorder + "B"
+        self._payload.append(pack(fstring, value))
+
+    def add_16bit_uint(self, value: int) -> None:
+        """Add a 16 bit unsigned int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = self._byteorder + "H"
+        self._payload.append(pack(fstring, value))
+
+    def add_32bit_uint(self, value: int) -> None:
+        """Add a 32 bit unsigned int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = "I"
+        # fstring = self._byteorder + "I"
+        p_string = self._pack_words(fstring, value)
+        self._payload.append(p_string)
+
+    def add_64bit_uint(self, value: int) -> None:
+        """Add a 64 bit unsigned int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = "Q"
+        p_string = self._pack_words(fstring, value)
+        self._payload.append(p_string)
+
+    def add_8bit_int(self, value: int) -> None:
+        """Add a 8 bit signed int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = self._byteorder + "b"
+        self._payload.append(pack(fstring, value))
+
+    def add_16bit_int(self, value: int) -> None:
+        """Add a 16 bit signed int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = self._byteorder + "h"
+        self._payload.append(pack(fstring, value))
+
+    def add_32bit_int(self, value: int) -> None:
+        """Add a 32 bit signed int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = "i"
+        p_string = self._pack_words(fstring, value)
+        self._payload.append(p_string)
+
+    def add_64bit_int(self, value: int) -> None:
+        """Add a 64 bit signed int to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = "q"
+        p_string = self._pack_words(fstring, value)
+        self._payload.append(p_string)
+
+    def add_16bit_float(self, value: float) -> None:
+        """Add a 16 bit float to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = "e"
+        p_string = self._pack_words(fstring, value)
+        self._payload.append(p_string)
+
+    def add_32bit_float(self, value: float) -> None:
+        """Add a 32 bit float to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = "f"
+        p_string = self._pack_words(fstring, value)
+        self._payload.append(p_string)
+
+    def add_64bit_float(self, value: float) -> None:
+        """Add a 64 bit float(double) to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = "d"
+        p_string = self._pack_words(fstring, value)
+        self._payload.append(p_string)
+
+    def add_string(self, value: str) -> None:
+        """Add a string to the buffer.
+
+        :param value: The value to add to the buffer
+        """
+
+        fstring = self._byteorder + str(len(value)) + "s"
+        self._payload.append(pack(fstring, value.encode()))
+
+
+class BinaryPayloadDecoder:
+    """A utility that helps decode payload messages from a modbus response message.
+
+    It really is just a simple wrapper around
+    the struct module, however it saves time looking up the format
+    strings. What follows is a simple example::
+
+        decoder = BinaryPayloadDecoder(payload)
+        first   = decoder.decode_8bit_uint()
+        second  = decoder.decode_16bit_uint()
+    """
+
+
+    def __init__(self, payload, byteorder=Endian.LITTLE, wordorder=Endian.BIG):
+        """Initialize a new payload decoder.
+
+        :param payload: The payload to decode with
+        :param byteorder: The endianness of the payload
+        :param wordorder: The endianness of the word (when wordcount is >= 2)
+        """
+        self._payload = payload
+        self._pointer = 0x00
+        self._byteorder = byteorder
+        self._wordorder = wordorder
+
+
+    @classmethod
+    def fromRegisters(
+        cls,
+        registers,
+        byteorder=Endian.LITTLE,
+        wordorder=Endian.BIG,
+    ):
+        """Initialize a payload decoder.
+
+        With the result of reading a collection of registers from a modbus device.
+
+        The registers are treated as a list of 2 byte values.
+        We have to do this because of how the data has already
+        been decoded by the rest of the library.
+
+        :param registers: The register results to initialize with
+        :param byteorder: The Byte order of each word
+        :param wordorder: The endianness of the word (when wordcount is >= 2)
+        :returns: An initialized PayloadDecoder
+        :raises ParameterException:
+        """
+
+        Log.debug("registers:{}", registers)
+        if isinstance(registers, list):  # repack into flat binary
+            payload = pack(f"!{len(registers)}H", *registers)
+            return cls(payload, byteorder, wordorder)
+        raise ParameterException("Invalid collection of registers supplied")
+
+    @classmethod
+    def bit_chunks(cls, coils, size=8):
+        """Return bit chunks."""
+        chunks = [coils[i : i + size] for i in range(0, len(coils), size)]
+        return chunks
+
+    @classmethod
+    def fromCoils(
+        cls,
+        coils,
+        byteorder=Endian.LITTLE,
+        _wordorder=Endian.BIG,
+    ):
+        """Initialize a payload decoder with the result of reading of coils."""
+        if isinstance(coils, list):
+            payload = b""
+            if padding := len(coils) % 8:  # Pad zeros
+                extra = [False] * padding
+                coils = extra + coils
+            chunks = cls.bit_chunks(coils)
+            for chunk in chunks:
+                payload += pack_bitstring(chunk[::-1])
+            return cls(payload, byteorder)
+        raise ParameterException("Invalid collection of coils supplied")
+
+    def _unpack_words(self, handle) -> bytes:
+        """Unpack words based on the word order and byte order.
+
+        # ---------------------------------------------- #
+        # Unpack in to network ordered unsigned integer  #
+        # Change Word order if little endian word order  #
+        # Pack values back based on correct byte order   #
+        # ---------------------------------------------- #
+        """
+        if Endian.LITTLE in {self._byteorder, self._wordorder}:
+            handle = array("H", handle)
+            if self._byteorder == Endian.LITTLE:
+                handle.byteswap()
+            if self._wordorder == Endian.LITTLE:
+                handle.reverse()
+            handle = handle.tobytes()
+        Log.debug("handle: {}", handle)
+        return handle
+
+    def reset(self):
+        """Reset the decoder pointer back to the start."""
+        self._pointer = 0x00
+
+    def decode_8bit_uint(self):
+        """Decode a 8 bit unsigned int from the buffer."""
+        self._pointer += 1
+        fstring = self._byteorder + "B"
+        handle = self._payload[self._pointer - 1 : self._pointer]
+        return unpack(fstring, handle)[0]
+
+    def decode_bits(self, package_len=1):
+        """Decode a byte worth of bits from the buffer."""
+        self._pointer += package_len
+        # fstring = self._endian + "B"
+        handle = self._payload[self._pointer - 1 : self._pointer]
+        return unpack_bitstring(handle)
+
+    def decode_16bit_uint(self):
+        """Decode a 16 bit unsigned int from the buffer."""
+        self._pointer += 2
+        fstring = self._byteorder + "H"
+        handle = self._payload[self._pointer - 2 : self._pointer]
+        return unpack(fstring, handle)[0]
+
+    def decode_32bit_uint(self):
+        """Decode a 32 bit unsigned int from the buffer."""
+        self._pointer += 4
+        fstring = "I"
+        handle = self._payload[self._pointer - 4 : self._pointer]
+        handle = self._unpack_words(handle)
+        return unpack("!" + fstring, handle)[0]
+
+    def decode_64bit_uint(self):
+        """Decode a 64 bit unsigned int from the buffer."""
+        self._pointer += 8
+        fstring = "Q"
+        handle = self._payload[self._pointer - 8 : self._pointer]
+        handle = self._unpack_words(handle)
+        return unpack("!" + fstring, handle)[0]
+
+    def decode_8bit_int(self):
+        """Decode a 8 bit signed int from the buffer."""
+        self._pointer += 1
+        fstring = self._byteorder + "b"
+        handle = self._payload[self._pointer - 1 : self._pointer]
+        return unpack(fstring, handle)[0]
+
+    def decode_16bit_int(self):
+        """Decode a 16 bit signed int from the buffer."""
+        self._pointer += 2
+        fstring = self._byteorder + "h"
+        handle = self._payload[self._pointer - 2 : self._pointer]
+        return unpack(fstring, handle)[0]
+
+    def decode_32bit_int(self):
+        """Decode a 32 bit signed int from the buffer."""
+        self._pointer += 4
+        fstring = "i"
+        handle = self._payload[self._pointer - 4 : self._pointer]
+        handle = self._unpack_words(handle)
+        return unpack("!" + fstring, handle)[0]
+
+    def decode_64bit_int(self):
+        """Decode a 64 bit signed int from the buffer."""
+        self._pointer += 8
+        fstring = "q"
+        handle = self._payload[self._pointer - 8 : self._pointer]
+        handle = self._unpack_words(handle)
+        return unpack("!" + fstring, handle)[0]
+
+    def decode_16bit_float(self):
+        """Decode a 16 bit float from the buffer."""
+        self._pointer += 2
+        fstring = "e"
+        handle = self._payload[self._pointer - 2 : self._pointer]
+        handle = self._unpack_words(handle)
+        return unpack("!" + fstring, handle)[0]
+
+    def decode_32bit_float(self):
+        """Decode a 32 bit float from the buffer."""
+        self._pointer += 4
+        fstring = "f"
+        handle = self._payload[self._pointer - 4 : self._pointer]
+        handle = self._unpack_words(handle)
+        return unpack("!" + fstring, handle)[0]
+
+    def decode_64bit_float(self):
+        """Decode a 64 bit float(double) from the buffer."""
+        self._pointer += 8
+        fstring = "d"
+        handle = self._payload[self._pointer - 8 : self._pointer]
+        handle = self._unpack_words(handle)
+        return unpack("!" + fstring, handle)[0]
+
+    def decode_string(self, size=1):
+        """Decode a string from the buffer.
+
+        :param size: The size of the string to decode
+        """
+        self._pointer += size
+        return self._payload[self._pointer - size : self._pointer]
+
+    def skip_bytes(self, nbytes):
+        """Skip n bytes in the buffer.
+
+        :param nbytes: The number of bytes to skip
+        """
+        self._pointer += nbytes

--- a/code/Python/support/classic_modbusdecoder.py
+++ b/code/Python/support/classic_modbusdecoder.py
@@ -1,177 +1,196 @@
 #!/usr/bin/env python
 
-# --------------------------------------------------------------------------- # 
-# Handle the modbus data from the Classic. 
-# The only methon called out of this is getModbusData
+# --------------------------------------------------------------------------- #
+# Handle the modbus data from the Classic.
+# The only method called out of this is getModbusData
 # This opens the client to the Classic, gets the data and closes it. It does not
 # keep the link open to the Classic.
-# --------------------------------------------------------------------------- # 
+#
+# 2024-12-31: Daniel Côté
+# - Extracted Payload from pymodbus 3.8.2 as it is deprecated and will be removed
+#   in next version.
+# - Removed check of pymodbus version
+# - Added "modbusClient = None" when closing to force a new TCP connection for
+#   multiple Classic installation and iterations.
+# - Added extra info about exceptions in except statements.
+# - Added decoding of certain fields such as MAC address AUX functions and unit name
+# --------------------------------------------------------------------------- #
 
 from pymodbus.constants import Endian
-from pymodbus.payload import BinaryPayloadDecoder
-try:
-    from pymodbus.client import ModbusTcpClient as ModbusClient  # pymodbus 3
-    MODBUS_VERSION = 3
-except ImportError:
-    from pymodbus.client.sync import ModbusTcpClient as ModbusClient  # pymodbus 2
-    MODBUS_VERSION = 2
+from pymodbus.client import ModbusTcpClient as ModbusClient
+from Payload import BinaryPayloadDecoder
 from collections import OrderedDict
 import logging
 import sys
 
-log = logging.getLogger('classic_mqtt')
+log = logging.getLogger("classic_modbusdecoder")
 
-# --------------------------------------------------------------------------- # 
+
+# --------------------------------------------------------------------------- #
 # Read from the address and return the registers
-# --------------------------------------------------------------------------- # 
-def getRegisters(theClient, addr, count):
+# --------------------------------------------------------------------------- #
+def getRegisters(theClient, addr, cnt):
     try:
-        if MODBUS_VERSION == 2:
-            result = theClient.read_holding_registers(addr, count, unit=10)
-        else:
-            result = theClient.read_holding_registers(addr, count, slave=10)
+        result = theClient.read_holding_registers(addr, count=cnt, slave=10)
         if result.function_code >= 0x80:
-            log.error("error getting {} for {} bytes".format(addr, count))
+            log.error(
+                "error getting {} for {} bytes, result.function_code >=0x80: {}".format(
+                    addr, count, result.function_code
+                )
+            )
             return {}
-    except:
-        log.error("Error getting {} for {} bytes".format(addr, count))
+    except Exception as ex:
+        log.error("Error getting {} for {} bytes, exeption:{}".format(addr, count, ex))
         return {}
 
     return result.registers
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Return a decoder for the passed in registers
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 def getDataDecoder(registers):
-    if MODBUS_VERSION == 2:
-        return BinaryPayloadDecoder.fromRegisters(
-            registers,
-            byteorder=Endian.Big,
-            wordorder=Endian.Little)
-    else:
-        return BinaryPayloadDecoder.fromRegisters(
-            registers,
-            byteorder=Endian.BIG,
-            wordorder=Endian.LITTLE)
+    return BinaryPayloadDecoder.fromRegisters(
+        registers, byteorder=Endian.BIG, wordorder=Endian.LITTLE
+    )
 
-# --------------------------------------------------------------------------- # 
+
+# --------------------------------------------------------------------------- #
 # Based on the address, return the decoded OrderedDict
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
+
+
 def doDecode(addr, decoder):
-    if (addr == 4100 ):
-        decoded = OrderedDict([
-            ('PCB', decoder.decode_8bit_uint()),                       #4101 MSB
-            ('Type', decoder.decode_8bit_uint()),                      #4101 LSB
-            ('Year', decoder.decode_16bit_uint()),                     #4102
-            ('Month', decoder.decode_8bit_uint()),                     #4103 MSB
-            ('Day', decoder.decode_8bit_uint()),                       #4103 LSB
-            ('InfoFlagBits3', decoder.decode_16bit_uint()),            #4104
-            ('ignore', decoder.skip_bytes(2)),                         #4105 Reserved
-            ('mac_1', decoder.decode_8bit_uint()),                     #4106 MSB  
-            ('mac_0', decoder.decode_8bit_uint()),                     #4106 LSB
-            ('mac_3', decoder.decode_8bit_uint()),                     #4107 MSB
-            ('mac_2', decoder.decode_8bit_uint()),                     #4107 LSB
-            ('mac_5', decoder.decode_8bit_uint()),                     #4108 MSB
-            ('mac_4', decoder.decode_8bit_uint()),                     #4108 LSB
-            ('ignore2', decoder.skip_bytes(4)),                        #4109, 4110
-            ('unitID', decoder.decode_32bit_uint()),                   #4111
-            ('StatusRoll', decoder.decode_16bit_uint()),               #4113
-            ('RsetTmms', decoder.decode_16bit_uint()),                 #4114
-            ('BatVoltage', decoder.decode_16bit_int()/10.0),           #4115
-            ('PVVoltage', decoder.decode_16bit_uint()/10.0),           #4116
-            ('BatCurrent', decoder.decode_16bit_uint()/10.0),          #4117
-            ('EnergyToday', decoder.decode_16bit_uint()/10.0),         #4118
-            ('Power', decoder.decode_16bit_uint()/1.0),                #4119
-            ('ChargeStage', decoder.decode_8bit_uint()),               #4120 MSB
-            ('State', decoder.decode_8bit_uint()),                     #4120 LSB
-            ('PVCurrent', decoder.decode_16bit_uint()/10.0),           #4121
-            ('lastVOC', decoder.decode_16bit_uint()/10.0),             #4122
-            ('HighestVinputLog', decoder.decode_16bit_uint()),         #4123
-            ('MatchPointShadow', decoder.decode_16bit_uint()),         #4124
-            ('AmpHours', decoder.decode_16bit_uint()),                 #4125
-            ('TotalEnergy', decoder.decode_32bit_uint()/10.0),         #4126, 4127
-            ('LifetimeAmpHours', decoder.decode_32bit_uint()),         #4128, 4129
-            ('InfoFlagsBits', decoder.decode_32bit_uint()),            #4130, 31
-            ('BatTemperature', decoder.decode_16bit_int()/10.0),       #4132
-            ('FETTemperature', decoder.decode_16bit_int()/10.0),       #4133
-            ('PCBTemperature', decoder.decode_16bit_int()/10.0),       #4134
-            ('NiteMinutesNoPwr', decoder.decode_16bit_uint()),         #4135
-            ('MinuteLogIntervalSec', decoder.decode_16bit_uint()),     #4136
-            ('modbus_port_register', decoder.decode_16bit_uint()),     #4137
-            ('FloatTimeTodaySeconds', decoder.decode_16bit_uint()),    #4138
-            ('AbsorbTime', decoder.decode_16bit_uint()),               #4139
-            ('reserved1', decoder.decode_16bit_uint()),                #4140
-            ('PWM_ReadOnly', decoder.decode_16bit_uint()),             #4141
-            ('Reason_For_Reset', decoder.decode_16bit_uint()),         #4142
-            ('EqualizeTime', decoder.decode_16bit_uint()),             #4143
-        ])
-    elif (addr == 4360):
-        decoded = OrderedDict([
-            ('WbangJrCmdS', decoder.decode_16bit_uint()),                   #4361
-            ('WizBangJrRawCurrent', decoder.decode_16bit_int()),            #4362
-            ('skip', decoder.skip_bytes(4)),                                #4363,4364
-            ('WbJrAmpHourPOSitive', decoder.decode_32bit_uint()),           #4365,4366
-            ('WbJrAmpHourNEGative', decoder.decode_32bit_int()),            #4367,4368
-            ('WbJrAmpHourNET', decoder.decode_32bit_int()),                 #4369,4370
-            ('WhizbangBatCurrent', decoder.decode_16bit_int()/10.0),        #4371
-            ('WizBangCRC', decoder.decode_8bit_int()),                      #4372 MSB
-            ('ShuntTemperature', decoder.decode_8bit_int() - 50.0),         #4372 LSB
-            ('SOC', decoder.decode_16bit_uint()),                           #4373
-            ('skip2', decoder.skip_bytes(6)),                               #4374,75, 76
-            ('RemainingAmpHours', decoder.decode_16bit_uint()),             #4377
-            ('skip3', decoder.skip_bytes(6)),                               #4378,79,80
-            ('TotalAmpHours', decoder.decode_16bit_uint()),                 #4381
-        ])
-    elif (addr == 4163):
-        decoded = OrderedDict([
-            ('MPPTMode', decoder.decode_16bit_uint()),                      #4164
-            ('Aux1and2Function', decoder.decode_16bit_int()),               #4165
-        ])
-    elif (addr == 4209):
-        decoded = OrderedDict([
-            ('Name0', decoder.decode_8bit_uint()),                      #4210-MSB
-            ('Name1', decoder.decode_8bit_uint()),                      #4210-LSB
-            ('Name2', decoder.decode_8bit_uint()),                      #4211-MSB
-            ('Name3', decoder.decode_8bit_uint()),                      #4211-LSB
-            ('Name4', decoder.decode_8bit_uint()),                      #4212-MSB
-            ('Name5', decoder.decode_8bit_uint()),                      #4212-LSB
-            ('Name6', decoder.decode_8bit_uint()),                      #4213-MSB
-            ('Name7', decoder.decode_8bit_uint()),                      #4213-LSB
-        ])
-    elif (addr == 4213):
-        decoded = OrderedDict([
-            ('CTIME0', decoder.decode_32bit_uint()),                    #4214+#4215
-            ('CTIME1', decoder.decode_32bit_uint()),                    #4216+#4217
-            ('CTIME2', decoder.decode_32bit_uint()),                    #4218+#4219
-        ])
-    elif (addr == 4243):
-        decoded = OrderedDict([
-            ('VbattRegSetPTmpComp', decoder.decode_16bit_int()/10.0),      #4244
-            ('nominalBatteryVoltage', decoder.decode_16bit_uint()),          #4245
-            ('endingAmps', decoder.decode_16bit_int()/10.0),               #4246
-            ('skip', decoder.skip_bytes(56)),                                #4247-4274
-            ('ReasonForResting', decoder.decode_16bit_uint()),               #4275
-        ])
-    elif (addr == 16386):
-        decoded = OrderedDict([
-            ('app_rev', decoder.decode_32bit_uint()),                     #16387, 16388
-            ('net_rev', decoder.decode_32bit_uint()),                     #16387, 16388
-        ])
+    if addr == 4100:
+        decoded = OrderedDict(
+            [
+                ("PCB", decoder.decode_8bit_uint()),  # 4101 MSB
+                ("Type", decoder.decode_8bit_uint()),  # 4101 LSB
+                ("Year", decoder.decode_16bit_uint()),  # 4102
+                ("Month", decoder.decode_8bit_uint()),  # 4103 MSB
+                ("Day", decoder.decode_8bit_uint()),  # 4103 LSB
+                ("InfoFlagBits3", decoder.decode_16bit_uint()),  # 4104
+                ("ignore", decoder.skip_bytes(2)),  # 4105 Reserved
+                ("mac_1", decoder.decode_8bit_uint()),  # 4106 MSB
+                ("mac_0", decoder.decode_8bit_uint()),  # 4106 LSB
+                ("mac_3", decoder.decode_8bit_uint()),  # 4107 MSB
+                ("mac_2", decoder.decode_8bit_uint()),  # 4107 LSB
+                ("mac_5", decoder.decode_8bit_uint()),  # 4108 MSB
+                ("mac_4", decoder.decode_8bit_uint()),  # 4108 LSB
+                ("ignore2", decoder.skip_bytes(4)),  # 4109, 4110
+                ("unitID", decoder.decode_32bit_uint()),  # 4111
+                ("StatusRoll", decoder.decode_16bit_uint()),  # 4113
+                ("RsetTmms", decoder.decode_16bit_uint()),  # 4114
+                ("BatVoltage", decoder.decode_16bit_int() / 10.0),  # 4115
+                ("PVVoltage", decoder.decode_16bit_uint() / 10.0),  # 4116
+                ("BatCurrent", decoder.decode_16bit_uint() / 10.0),  # 4117
+                ("EnergyToday", decoder.decode_16bit_uint() / 10.0),  # 4118
+                ("Power", decoder.decode_16bit_uint() / 1.0),  # 4119
+                ("ChargeStage", decoder.decode_8bit_uint()),  # 4120 MSB
+                ("State", decoder.decode_8bit_uint()),  # 4120 LSB
+                ("PVCurrent", decoder.decode_16bit_uint() / 10.0),  # 4121
+                ("lastVOC", decoder.decode_16bit_uint() / 10.0),  # 4122
+                ("HighestVinputLog", decoder.decode_16bit_uint()),  # 4123
+                ("MatchPointShadow", decoder.decode_16bit_uint()),  # 4124
+                ("AmpHours", decoder.decode_16bit_uint()),  # 4125
+                ("TotalEnergy", decoder.decode_32bit_uint() / 10.0),  # 4126, 4127
+                ("LifetimeAmpHours", decoder.decode_32bit_uint()),  # 4128, 4129
+                ("InfoFlagsBits", decoder.decode_32bit_uint()),  # 4130, 31
+                ("BatTemperature", decoder.decode_16bit_int() / 10.0),  # 4132
+                ("FETTemperature", decoder.decode_16bit_int() / 10.0),  # 4133
+                ("PCBTemperature", decoder.decode_16bit_int() / 10.0),  # 4134
+                ("NiteMinutesNoPwr", decoder.decode_16bit_uint()),  # 4135
+                ("MinuteLogIntervalSec", decoder.decode_16bit_uint()),  # 4136
+                ("modbus_port_register", decoder.decode_16bit_uint()),  # 4137
+                ("FloatTimeTodaySeconds", decoder.decode_16bit_uint()),  # 4138
+                ("AbsorbTime", decoder.decode_16bit_uint()),  # 4139
+                ("reserved1", decoder.decode_16bit_uint()),  # 4140
+                ("PWM_ReadOnly", decoder.decode_16bit_uint()),  # 4141
+                ("Reason_For_Reset", decoder.decode_16bit_uint()),  # 4142
+                ("EqualizeTime", decoder.decode_16bit_uint()),  # 4143
+            ]
+        )
+    elif addr == 4360:
+        decoded = OrderedDict(
+            [
+                ("WbangJrCmdS", decoder.decode_16bit_uint()),  # 4361
+                ("WizBangJrRawCurrent", decoder.decode_16bit_int()),  # 4362
+                ("skip", decoder.skip_bytes(4)),  # 4363,4364
+                ("WbJrAmpHourPOSitive", decoder.decode_32bit_uint()),  # 4365,4366
+                ("WbJrAmpHourNEGative", decoder.decode_32bit_int()),  # 4367,4368
+                ("WbJrAmpHourNET", decoder.decode_32bit_int()),  # 4369,4370
+                ("WhizbangBatCurrent", decoder.decode_16bit_int() / 10.0),  # 4371
+                ("WizBangCRC", decoder.decode_8bit_int()),  # 4372 MSB
+                ("ShuntTemperature", decoder.decode_8bit_int() - 50.0),  # 4372 LSB
+                ("SOC", decoder.decode_16bit_uint()),  # 4373
+                ("skip2", decoder.skip_bytes(6)),  # 4374,75, 76
+                ("RemainingAmpHours", decoder.decode_16bit_uint()),  # 4377
+                ("skip3", decoder.skip_bytes(6)),  # 4378,79,80
+                ("TotalAmpHours", decoder.decode_16bit_uint()),  # 4381
+            ]
+        )
+    elif addr == 4163:
+        decoded = OrderedDict(
+            [
+                ("MPPTMode", decoder.decode_16bit_uint()),  # 4164
+                ("Aux1Function", decoder.decode_8bit_int()),  # 4165
+                ("Aux2Function", decoder.decode_8bit_int()),  # 4165
+            ]
+        )
+    elif addr == 4209:
+        decoded = OrderedDict(
+            [
+                ("Name0", decoder.decode_8bit_uint()),  # 4210-MSB
+                ("Name1", decoder.decode_8bit_uint()),  # 4210-LSB
+                ("Name2", decoder.decode_8bit_uint()),  # 4211-MSB
+                ("Name3", decoder.decode_8bit_uint()),  # 4211-LSB
+                ("Name4", decoder.decode_8bit_uint()),  # 4212-MSB
+                ("Name5", decoder.decode_8bit_uint()),  # 4212-LSB
+                ("Name6", decoder.decode_8bit_uint()),  # 4213-MSB
+                ("Name7", decoder.decode_8bit_uint()),  # 4213-LSB
+            ]
+        )
+    elif addr == 4213:
+        decoded = OrderedDict(
+            [
+                ("CTIME0", decoder.decode_32bit_uint()),  # 4214+#4215
+                ("CTIME1", decoder.decode_32bit_uint()),  # 4216+#4217
+                ("CTIME2", decoder.decode_32bit_uint()),  # 4218+#4219
+            ]
+        )
+    elif addr == 4243:
+        decoded = OrderedDict(
+            [
+                ("VbattRegSetPTmpComp", decoder.decode_16bit_int() / 10.0),  # 4244
+                ("nominalBatteryVoltage", decoder.decode_16bit_uint()),  # 4245
+                ("endingAmps", decoder.decode_16bit_int() / 10.0),  # 4246
+                ("skip", decoder.skip_bytes(56)),  # 4247-4274
+                ("ReasonForResting", decoder.decode_16bit_uint()),  # 4275
+            ]
+        )
+    elif addr == 16386:
+        decoded = OrderedDict(
+            [
+                ("app_rev", decoder.decode_32bit_uint()),  # 16387, 16388
+                ("net_rev", decoder.decode_32bit_uint()),  # 16387, 16388
+            ]
+        )
 
     return decoded
 
-# --------------------------------------------------------------------------- # 
-# Get the data from the Classic. 
-# Open the cleint, read in the register, close the client, decode the data, 
-# combine it and return it 
-# --------------------------------------------------------------------------- # 
+
+# --------------------------------------------------------------------------- #
+# Get the data from the Classic.
+# Open the cleint, read in the register, close the client, decode the data,
+# combine it and return it
+# --------------------------------------------------------------------------- #
 
 modbusClient = None
 isConnected = False
 
+
 def getModbusData(modeAwake, classicHost, classicPort):
-    
+
     global isConnected, modbusClient
 
     try:
@@ -180,92 +199,197 @@ def getModbusData(modeAwake, classicHost, classicPort):
             if modbusClient is None:
                 modbusClient = ModbusClient(host=classicHost, port=classicPort)
 
-            #Test for successful connect, if not, log error and mark modbusConnected = False
+            # Test for successful connect, if not, log error and mark modbusConnected = False
             modbusClient.connect()
 
-            if MODBUS_VERSION == 2:
-                result = modbusClient.read_holding_registers(4163, 2, unit=10)
-            else:
-                result = modbusClient.read_holding_registers(4163, 2, slave=10)
+            result = modbusClient.read_holding_registers(4163, count=2, slave=10)
 
             if result.isError():
                 # close the client
                 log.error("MODBUS isError H:{} P:{}".format(classicHost, classicPort))
                 modbusClient.close()
                 isConnected = False
+                modbusClient = None  # Ajouté par Daniel Côté
                 return {}
 
             isConnected = True
 
         theData = {}
-        #Read in all the registers at one time
-        theData[4100] = getRegisters(theClient=modbusClient,addr=4100,count=44)
-        theData[4360] = getRegisters(theClient=modbusClient,addr=4360,count=22)
-        theData[4163] = getRegisters(theClient=modbusClient,addr=4163,count=2)
-        theData[4209] = getRegisters(theClient=modbusClient,addr=4209,count=4)
-        theData[4213] = getRegisters(theClient=modbusClient,addr=4213,count=6)
-        theData[4243] = getRegisters(theClient=modbusClient,addr=4243,count=32)
-        theData[16386]= getRegisters(theClient=modbusClient,addr=16386,count=4)
-        
-        #If we are snoozing, then give up the connection
-        #log.debug("modeAwake:{}".format(modeAwake))
-        if not modeAwake :
+        # Read in all the registers at one time
+        log.debug("Read in all the registers at one time")
+        theData[4100] = getRegisters(theClient=modbusClient, addr=4100, cnt=44)
+        theData[4360] = getRegisters(theClient=modbusClient, addr=4360, cnt=22)
+        theData[4163] = getRegisters(theClient=modbusClient, addr=4163, cnt=2)
+        theData[4209] = getRegisters(theClient=modbusClient, addr=4209, cnt=4)
+        theData[4213] = getRegisters(theClient=modbusClient, addr=4213, cnt=6)
+        theData[4243] = getRegisters(theClient=modbusClient, addr=4243, cnt=32)
+        theData[16386] = getRegisters(theClient=modbusClient, addr=16386, cnt=4)
+
+        # If we are snoozing, then give up the connection
+        log.debug("modeAwake:{}".format(modeAwake))
+        if not modeAwake:
             log.debug("Closing the modbus Connection, we are in Snooze mode")
             modbusClient.close()
             isConnected = False
+            modbusClient = None  # Ajouté par Daniel Côté
 
-    except: # Catch all modbus excpetions
+    except Exception as ex:  # Catch all modbus excpetions
         e = sys.exc_info()[0]
-        log.error("MODBUS Error H:{} P:{} e:{}".format(classicHost, classicPort, e))
+        log.error(
+            "MODBUS ErrorH:{} P:{} e:{}, ex: {}".format(classicHost, classicPort, e, ex)
+        )
         try:
             modbusClient.close()
             isConnected = False
+            modbusClient = None  # Ajouté par Daniel Côté
 
-        except:
-            log.error("MODBUS Error on close H:{} P:{}".format(classicHost, classicPort))
+        except Exception as ex:
+            log.error(
+                "MODBUS Error on close H:{} P:{} ex: {}".format(
+                    classicHost, classicPort
+                ),
+                ex,
+            )
 
         return {}
 
-    log.debug("Got data from Classic at {}:{}".format(classicHost,classicPort))
+    log.debug("Got data from Classic at {}:{}".format(classicHost, classicPort))
 
-    #Iterate over them and get the decoded data all into one dict
+    # Iterate over them and get the decoded data all into one dict
     decoded = {}
     for index in theData:
-        decoded = {**dict(decoded), **dict(doDecode(index, getDataDecoder(theData[index])))}
+        decoded = {
+            **dict(decoded),
+            **dict(doDecode(index, getDataDecoder(theData[index]))),
+        }
 
     # Device type 251 is different
-    if decoded['Type'] == 251:
-        decoded['Type'] = '250 KS'
+    if decoded["Type"] == 251:
+        decoded["Type"] = "250 KS"
 
     # IP number
-    decoded['IP'] = classicHost
+    decoded["IP"] = classicHost
+    # MAC address
+    decoded["MAC"] = ":".join(
+        f"{octet:02X}"
+        for octet in (
+            decoded["mac_5"],
+            decoded["mac_4"],
+            decoded["mac_3"],
+            decoded["mac_2"],
+            decoded["mac_1"],
+            decoded["mac_0"],
+        )
+    )
+    # Device name
+    decoded["Name"] = "".join(
+        chr(char)
+        for char in (
+            decoded["Name1"],
+            decoded["Name0"],
+            decoded["Name3"],
+            decoded["Name2"],
+            decoded["Name5"],
+            decoded["Name4"],
+            decoded["Name7"],
+            decoded["Name6"],
+        )
+    )
 
     # Charge State icon
-    decoded['ChargeStateIcon'] = 'mdi:music-rest-whole'
-    if decoded['ChargeStage'] == 3 or decoded['ChargeStage'] == 4:
-        decoded['ChargeStateIcon'] = 'mdi:battery-charging'
-    elif decoded['ChargeStage'] == 5 or decoded['ChargeStage'] == 6:
-        decoded['ChargeStateIcon'] = 'mdi:format-float-center'
-    elif decoded['ChargeStage'] >= 7:
-        decoded['ChargeStateIcon'] = 'mdi:approximately-equal'
+    decoded["ChargeStateIcon"] = "mdi:music-rest-whole"
+    if decoded["ChargeStage"] == 3 or decoded["ChargeStage"] == 4:
+        decoded["ChargeStateIcon"] = "mdi:battery-charging"
+    elif decoded["ChargeStage"] == 5 or decoded["ChargeStage"] == 6:
+        decoded["ChargeStateIcon"] = "mdi:format-float-center"
+    elif decoded["ChargeStage"] >= 7:
+        decoded["ChargeStateIcon"] = "mdi:approximately-equal"
     #
     chrg_stt_txt_arr = {
-        0: 'Resting',
-        3: 'Absorb',
-        4: 'Bulk MPPT',
-        5: 'Float',
-        6: 'Float MPPT',
-        7: 'Equalize',
-        10: 'HyperVOC',
-        18: 'Equalize MPPT',
-        }
-    decoded['ChargeStateText'] = chrg_stt_txt_arr[decoded['ChargeStage']]
+        0: "Resting",
+        3: "Absorb",
+        4: "Bulk MPPT",
+        5: "Float",
+        6: "Float MPPT",
+        7: "Equalize",
+        10: "HyperVOC",
+        18: "Equalize MPPT",
+    }
 
+    try:
+        decoded["ChargeStateText"] = chrg_stt_txt_arr[decoded["ChargeStage"]]
+    except:
+        log.error(
+            "ChargeStateText error. Undefined value:{}".format(decoded["ChargeStage"])
+        )
+        decoded["ChargeStateText"] = "No text defined for this value...{}".format(
+            str(decoded["ChargeStage"])
+        )
+
+    # AUX configured function
+    AUX_funct = {
+        0: "DIVERSION HIGH PWM",
+        1: "DIVERSION LOW PWM",
+        2: "WASTE NOT HIGH",
+        3: "WASTE NOT LOW",
+        4: "RESERVED",
+        5: "RESERVED",
+        6: "TOGGLE TEST",
+        7: "PV V ON HIGH",
+        8: "PV V ON LOW",
+        9: "RESERVED",
+        10: "WIND CLIPPER CONTROL",
+        11: "NITE LIGHT HIGH",
+        12: "DAY LIGHT HIGH",
+        13: "FLOAT HIGH OUTPUT",
+        14: "FLOAT LOW OUTPUT",
+        15: "Active HIGH (input) turn off",
+        16: "Active LOW (input) turn off",
+        17: "Active HIGH (input) Float",
+        18: "Whizbang Junior (WB Jr.)",
+    }
+    try:
+        decoded["Aux1FunctionText"] = AUX_funct[decoded["Aux1Function"]]
+    except:
+        log.error(
+            "Aux1FunctionText error. Undefined value:{}".format(decoded["Aux1Function"])
+        )
+        decoded["Aux1FunctionText"] = "No text defined for this value...{}".format(
+            str(decoded["Aux1Function"])
+        )
+    try:
+        decoded["Aux2FunctionText"] = AUX_funct[decoded["Aux2Function"]]
+    except:
+        log.error(
+            "Aux2FunctionText error. Undefined value:{}".format(decoded["Aux2Function"])
+        )
+        decoded["Aux2FunctionText"] = "No text defined for this value...{}".format(
+            str(decoded["Aux2Function"])
+        )
+
+    # MPPT Mode
+    mppt_mode = {
+        1: "PV_Uset",
+        3: "DYNAMIC",
+        5: "WIND TRACK",
+        7: "RESERVED",
+        9: "Legacy P&O",
+        11: "SOLAR",
+        13: "HYDRO",
+        15: "RESERVED",
+    }
+    try:
+        decoded["MPPTModeText"] = mppt_mode[decoded["MPPTMode"]]
+    except:
+        log.error("MPPTModeText error. Undefined value:{}".format(decoded["MPPTMode"]))
+        decoded["MPPTModeText"] = "No text defined for this value...{}".format(
+            str(decoded["MPPTMode"])
+        )
     # SOC icon
     SOCicon = "mdi:battery-"
     if decoded["ChargeStage"] == 3 or decoded["ChargeStage"] == 4:
         SOCicon = SOCicon + "charging-"
-    SOCicon = SOCicon + str( int( int(decoded["SOC"]) / 10 ) ) + "0"
+    SOCicon = SOCicon + str(int(int(decoded["SOC"]) / 10)) + "0"
     if SOCicon == "mdi:battery-100":
         SOCicon = "mdi:battery"
     decoded["SOCicon"] = SOCicon
@@ -302,14 +426,15 @@ def getModbusData(modeAwake, classicHost, classicPort):
         33: "OCP in a mode other than Solar or PV-Uset",
         34: "AD1CH.IbattMinus > 900 Peak negative battery current > 90.0 amps (Classic 150, 200)",
         35: "Battery voltage is less than Low Battery Disconnect (LBD) Typically Vbatt is less than 8.5 volts",
+        38: "Raison non définie dans classic_modbusdecoder.py...",
         104: "104?=14?: PV input is available but V is rising too slowly. Low Light or bad connection(Solar mode)",
-        111: "Normal Power up boot."
-        }
+        111: "Normal Power up boot.",
+    }
     try:
         idx = decoded["ReasonForResting"]
         decoded["ReasonForRestingText"] = rest_reason_arr[idx]
     except:
         log.error("ReasonForRestingText Error index:{}".format(idx))
-        decoded["ReasonForRestingText"] = "Unknown"
+        decoded["ReasonForRestingText"] = "Unknown code: {}".format(idx)
 
     return decoded


### PR DESCRIPTION

- Extracted Payload from pymodbus 3.8.2 as it is deprecated and will be removed in next version.
- Removed check of pymodbus version
- Added "modbusClient = None" when closing to force a new TCP connection for multiple Classic installation and iterations.
- Added extra info about exceptions in except statements.
- Added decoding of certain fields such as MAC address AUX functions and unit name
Regards,

Daniel.